### PR TITLE
Updated the typo in Unified Groups REST url

### DIFF
--- a/content/overview/overview.md
+++ b/content/overview/overview.md
@@ -1,4 +1,4 @@
-
+﻿
 
 
 # Overview of Microsoft Graph
@@ -34,7 +34,7 @@ The following are some examples of common queries using Microsoft Graph API:
 |   GET my calendar |	`https://graph.microsoft.com/v1.0/me/calendar` |
 |   GET my manager	| `https://graph.microsoft.com/v1.0/me/manager` |
 |   GET last user to modify file foo.txt |	`https://graph.microsoft.com/v1.0/me/drive/root/items/foo.txt/lastModifiedByUser` |
-|   GET unified groups I’m member of|	`https://graph.microsoft.com/v1.0/me/memberOf/$/microsoft.graph.group?$filter=groupTypes/any(a:a eq 'unified')` |
+|   GET unified groups I’m member of|	`https://graph.microsoft.com/v1.0/me/memberOf/$/microsoft.graph.group$filter=groupTypes/any(a:a eq 'unified')` |
 |   GET users in my organization	 | `https://graph.microsoft.com/v1.0/users` |
 |   GET group conversations |	`https://graph.microsoft.com/v1.0/groups/<id>/conversations` |
 |   GET people related to me	| `https://graph.microsoft.com/beta/me/people` |

--- a/content/overview/overview.md
+++ b/content/overview/overview.md
@@ -34,7 +34,7 @@ The following are some examples of common queries using Microsoft Graph API:
 |   GET my calendar |	`https://graph.microsoft.com/v1.0/me/calendar` |
 |   GET my manager	| `https://graph.microsoft.com/v1.0/me/manager` |
 |   GET last user to modify file foo.txt |	`https://graph.microsoft.com/v1.0/me/drive/root/items/foo.txt/lastModifiedByUser` |
-|   GET unified groups I’m member of|	`https://graph.microsoft.com/v1.0/me/memberOf/$/microsoft.graph.group$filter=groupTypes/any(a:a eq 'unified')` |
+|   GET unified groups I’m member of|	`https://graph.microsoft.com/v1.0/me/memberOf/$/microsoft.graph.group?$filter=groupTypes/any(a:a%20eq%20'unified')` |
 |   GET users in my organization	 | `https://graph.microsoft.com/v1.0/users` |
 |   GET group conversations |	`https://graph.microsoft.com/v1.0/groups/<id>/conversations` |
 |   GET people related to me	| `https://graph.microsoft.com/beta/me/people` |


### PR DESCRIPTION
Removed the additional ? from the section text

Before this had a ? after the microsoft.graph.group section which meant the REST call ended up returning all groups.

GET unified groups I’m member of|
`https://graph.microsoft.com/v1.0/me/memberOf/$/microsoft.graph.group$filter=groupTypes/any(a:a
eq 'unified')