### PR TITLE
Update message_move.md

### DIFF
--- a/api-reference/v1.0/api/message_move.md
+++ b/api-reference/v1.0/api/message_move.md
@@ -23,7 +23,7 @@ In the request body, provide a JSON object with the following parameters.
 
 | Parameter	   | Type	|Description|
 |:---------------|:--------|:----------|
-|destinationId|String||
+|DestinationId|String||
 
 ### Response
 If successful, this method returns `201, Created` response code and [Message](../resources/message.md) object in the response body.
@@ -42,7 +42,7 @@ Content-type: application/json
 Content-length: 44
 
 {
-  "destinationId": "destinationId-value"
+  "DestinationId": "destinationId-value"
 }
 ```
 


### PR DESCRIPTION
It appears as though the API is expecting 'DestinationId'.  When sending the request with 'destinationId', this message is returned:

"{\r\n  \"error\": {\r\n    \"code\": \"ErrorInvalidParameter\",\r\n    \"message\": \"The value of the parameter 'DestinationId' is empty.\",\r\n    \"innerError\": {\r\n      \"request-id\": \"65079e98-2477-4de0-9025-5e7e5d05b6e1\",\r\n      \"date\": \"2015-12-01T22:26:58\"\r\n    }\r\n  }\r\n}"

The message indicates that it's expecting 'DestinationId'.  Using 'DestinationId', as requested by the API, works fine.