### PR TITLE
In opentypeextension resource file, clearly related the type with a d…

### DIFF
--- a/api-reference/beta/resources/contact.md
+++ b/api-reference/beta/resources/contact.md
@@ -115,8 +115,8 @@ Here is a JSON representation of the resource
 |[Create](../api/user_post_contacts.md) | [contact](contact.md) |Add a contact to the root Contacts folder or to the contacts endpoint of another contact folder.|
 |[Update](../api/contact_update.md) | [contact](contact.md) |Update contact object. |
 |[Delete](../api/contact_delete.md) | None |Delete contact object. |
-|[Create openTypeExtension](../api/opentypeextension_post_opentypeextension.md) |[openTypeExtension](opentypeextension.md)| Create an open type data extension and add custom properties in a new or existing instance of a resource.|
-|[Get openTypeExtension](../api/opentypeextension_get.md) |[openTypeExtension](opentypeextension.md) collection| Get an **openTypeExtension** object or objects identified by name or fully qualified name.|
+|[Create data extension](../api/opentypeextension_post_opentypeextension.md) |[openTypeExtension](opentypeextension.md)| Create an open type data extension and add custom properties in a new or existing instance of a resource.|
+|[Get data extension](../api/opentypeextension_get.md) |[openTypeExtension](opentypeextension.md) collection| Get an **openTypeExtension** object or objects identified by name or fully qualified name.|
 
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79

--- a/api-reference/beta/resources/event.md
+++ b/api-reference/beta/resources/event.md
@@ -116,8 +116,8 @@ Here is a JSON representation of the resource
 |[List instances](../api/event_list_instances.md) |[Event](event.md) collection| Get a Event object collection.|
 |[List attachments](../api/event_list_attachments.md) |[Attachment](attachment.md) collection| Get a Attachment object collection.|
 |[Create Attachment](../api/event_post_attachments.md) |[Attachment](attachment.md)| Create a new Attachment by posting to the attachments collection.|
-|[Create openTypeExtension](../api/opentypeextension_post_opentypeextension.md) |[openTypeExtension](opentypeextension.md)| Create an open type data extension and add custom properties in a new or existing instance of a resource.|
-|[Get openTypeExtension](../api/opentypeextension_get.md) |[openTypeExtension](opentypeextension.md) collection| Get an **openTypeExtension** object or objects identified by name or fully qualified name.|
+|[Create data extension](../api/opentypeextension_post_opentypeextension.md) |[openTypeExtension](opentypeextension.md)| Create an open type data extension and add custom properties in a new or existing instance of a resource.|
+|[Get data extension](../api/opentypeextension_get.md) |[openTypeExtension](opentypeextension.md) collection| Get an **openTypeExtension** object or objects identified by name or fully qualified name.|
 
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79

--- a/api-reference/beta/resources/message.md
+++ b/api-reference/beta/resources/message.md
@@ -126,8 +126,8 @@ When a message is being composed, in most cases, the From and Sender properties 
 |[replyAll](../api/message_replyall.md)|None|Reply to all the recipients of a message by specifying a comment and modifying any updateable properties for the reply, all by using the **replyAll** method. The message is then saved in the Sent Items folder.|
 |[send](../api/message_send.md)|None|Sends a previously created message draft. The message is then saved in the Sent Items folder.|
 |[unsubscribe](../api/message_unsubscribe.md)|None|Send a message using the data and address specified in the first mailto command in the List-Unsubscribe header.|
-|[Create openTypeExtension](../api/opentypeextension_post_opentypeextension.md) |[openTypeExtension](opentypeextension.md)| Create an open type data extension and add custom properties in a new or existing instance of a resource.|
-|[Get openTypeExtension](../api/opentypeextension_get.md) |[openTypeExtension](opentypeextension.md) collection| Get an **openTypeExtension** object or objects identified by name or fully qualified name.|
+|[Create data extension](../api/opentypeextension_post_opentypeextension.md) |[openTypeExtension](opentypeextension.md)| Create an open type data extension and add custom properties in a new or existing instance of a resource.|
+|[Get data extension](../api/opentypeextension_get.md) |[openTypeExtension](opentypeextension.md) collection| Get an **openTypeExtension** object or objects identified by name or fully qualified name.|
 
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79

--- a/api-reference/beta/resources/opentypeextension.md
+++ b/api-reference/beta/resources/opentypeextension.md
@@ -3,8 +3,8 @@
 An **openTypeExtension** is an OData v4 open type which allows you to specify at runtime custom data in instances of resources 
 defined in the Entity Data Model. This saves you time in defining new entity types just for this purpose.
 
-You can create data extensions in a message, event, or contact in the signed-in user's
-mailbox, or in an event in a group calendar of an organization. In the individual-user context, the user's 
+You can create data extensions of the **openTypeExtension** type in a [message](message.md), [event](event.md), or [contact](contact.md) in the signed-in user's
+mailbox, or in an **event** in a group calendar of an organization. In the individual-user context, the user's 
 account can be in Office 365 or a Microsoft account (Hotmail.com, Live.com, MSN.com, Outlook.com and Passport.com).
 
 This resource is derived from the [extension](extension.md) abstract type and has the additional **extensionName** property.

--- a/api-reference/beta/resources/post.md
+++ b/api-reference/beta/resources/post.md
@@ -3,6 +3,7 @@
 Represents an individual Post item within a [converstaionThread](conversationthread.md) entity.
 
 A new post is created when you:
+
 - [Reply to an existing post](../api/post_reply.md) 
 - [Reply to an existing thread](../api/conversationthread_reply.md) 
 - [Create a thread in a new conversation](../api/group_post_threads.md)
@@ -76,8 +77,8 @@ Here is a JSON representation of the resource
 |[Forward](../api/post_forward.md)|None|Forward a post to a recipient.|
 |[List attachments](../api/post_list_attachments.md) |[attachment](attachment.md) collection| Get a list of Attachment objects attached to a post.|
 |[Create Attachment](../api/post_post_attachments.md) |[attachment](attachment.md)| Add an attachment to a post. |
-|[Create openTypeExtension](../api/opentypeextension_post_opentypeextension.md) |[openTypeExtension](opentypeextension.md)| Create an open type data extension and add custom properties in a new or existing instance of a resource.|
-|[Get openTypeExtension](../api/opentypeextension_get.md) |[openTypeExtension](opentypeextension.md) collection| Get an **openTypeExtension** object or objects identified by name or fully qualified name.|
+|[Create data extension](../api/opentypeextension_post_opentypeextension.md) |[openTypeExtension](opentypeextension.md)| Create an open type data extension and add custom properties in a new or existing instance of a resource.|
+|[Get data extension](../api/opentypeextension_get.md) |[openTypeExtension](opentypeextension.md) collection| Get an **openTypeExtension** object or objects identified by name or fully qualified name.|
 
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79


### PR DESCRIPTION
…ata extension. In the other supporting resource files, updated link text in their method tables to say create (or get) data extensions, to be consistent with TOC.