### PR TITLE
remove second github links

### DIFF
--- a/content/overview/overview.md
+++ b/content/overview/overview.md
@@ -3,10 +3,6 @@
 
 # Overview of Microsoft Graph
 
-|  ![](./images/GitHub-Mark-64px.png) | **Contribute to this content.** <br /> Use GitHub to [suggest changes](https://github.com/OfficeDev/microsoft-graph-docs).  |
-|---|:---|
-
-
 Microsoft Graph (previously called Office 365 unified API) exposes multiple APIs from Microsoft cloud services through a single REST API endpoint (**https://graph.microsoft.com**). Using the Microsoft Graph, you can turn formerly difficult or complex queries into simple navigations. 
  
 The Microsoft Graph gives you:


### PR DESCRIPTION
Remove the GitHub links now that they are available on every page.