### PR TITLE
Fixed documentation error

### DIFF
--- a/api-reference/api/item_delta.md
+++ b/api-reference/api/item_delta.md
@@ -198,11 +198,8 @@ driveItem properties:
 
 * **createdBy**
 * **cTag**
-* **eTag**
 * **fileSystemInfo**
 * **lastModifiedBy**
-* **parentReference**
-* **size**
 
 
 <!-- {


### PR DESCRIPTION
The documentation incorrectly states that eTag, parentReference and
size are not returned by 'delta' with OneDrive for Business. Fixes #314