### PR TITLE
CHANGE: G$; Version 1.0 does not support direct updates of assignedLi…

### DIFF
--- a/api-reference/api/user_update.md
+++ b/api-reference/api/user_update.md
@@ -70,25 +70,10 @@ Content-length: 491
 
 {
   "accountEnabled": true,
-  "assignedLicenses": [
-    {
-      "disabledPlans": [ "bea13e0c-3828-4daa-a392-28af7ff61a0f" ],
-      "skuId": "skuId-value"
-    }
-  ],
-  "assignedPlans": [
-    {
-      "assignedDateTime": "datetime-value",
-      "capabilityStatus": "capabilityStatus-value",
-      "service": "service-value",
-      "servicePlanId": "bea13e0c-3828-4daa-a392-28af7ff61a0f"
-    }
-  ],
   "businessPhones": [
     "businessPhones-value"
   ],
-  "city": "city-value",
-  "companyName": "companyName-value"
+  "city": "city-value"
 }
 ```
 ##### Response
@@ -105,25 +90,10 @@ Content-length: 491
 
 {
   "accountEnabled": true,
-  "assignedLicenses": [
-    {
-      "disabledPlans": [ "bea13e0c-3828-4daa-a392-28af7ff61a0f" ],
-      "skuId": "skuId-value"
-    }
-  ],
-  "assignedPlans": [
-    {
-      "assignedDateTime": "datetime-value",
-      "capabilityStatus": "capabilityStatus-value",
-      "service": "service-value",
-      "servicePlanId": "servicePlanId-value"
-    }
-  ],
   "businessPhones": [
     "businessPhones-value"
   ],
-  "city": "city-value",
-  "companyName": "companyName-value"
+  "city": "city-value"
 }
 ```
 


### PR DESCRIPTION
To whom it may concern.

CHANGE: G$; Version **1.0** does not support direct updates of _assignedLicenses_, _assignedPlans_ attributes through User entity PATCH request. Such updates are only possible using _assignLicense_ method. Note that currently **Beta** does not support such request either.
CHANGE: G$; _CompanyName_ attribute cannot be updated neither with version **1.0** nor **Beta**. Given examples make initial evaluation of Graph functionality hard for a new customer

Would suggest giving other attribute updates as a usage example, i.e. _immutableId_ for non-federated identity or simply _surname_.