### PR TITLE
Fixed documentation error (wrong HTTP method)

### DIFF
--- a/api-reference/beta/api/table_range.md
+++ b/api-reference/beta/api/table_range.md
@@ -6,8 +6,8 @@ The following **scopes** are required to execute this API:
 ### HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-POST /workbook/tables(<id|name>)/Range
-POST /workbook/worksheets(<id|name>)/tables(<id|name>)/Range
+GET /workbook/tables(<id|name>)/Range
+GET /workbook/worksheets(<id|name>)/tables(<id|name>)/Range
 
 ```
 ### Request headers
@@ -30,7 +30,7 @@ Here is an example of the request.
   "name": "table_range"
 }-->
 ```http
-POST https://graph.microsoft.com/beta/me/drive/items/<id>/workbook/tables(<id|name>)/Range
+GET https://graph.microsoft.com/beta/me/drive/items/<id>/workbook/tables(<id|name>)/Range
 ```
 
 ##### Response


### PR DESCRIPTION
Documentation states that a POST method is used to get a range object of a table (/workbook/tables('id or name')/Range). Should be a GET method.
http://graph.microsoft.io/en-us/docs/api-reference/beta/api/table_range