### PR TITLE
Remove password parameter from protect action.

### DIFF
--- a/api-reference/v1.0/api/worksheetprotection_protect.md
+++ b/api-reference/v1.0/api/worksheetprotection_protect.md
@@ -21,7 +21,6 @@ In the request body, provide a JSON object with the following parameters.
 | Parameter	   | Type	|Description|
 |:---------------|:--------|:----------|
 |options|WorksheetProtectionOptions|Optional. sheet protection options.|
-|password|string|Optional. sheet protection password.|
 
 ### Response
 If successful, this method returns `200, OK` response code. It does not return anything in the response body.

--- a/api-reference/v1.0/api/worksheetprotection_protect.md
+++ b/api-reference/v1.0/api/worksheetprotection_protect.md
@@ -51,8 +51,7 @@ Content-length: 383
     "allowSort": true,
     "allowAutoFilter": true,
     "allowPivotTables": true
-  },
-  "password": "password-value"
+  }
 }
 ```
 


### PR DESCRIPTION
The **protect** action checked into the current v1.0 metadata does not have a password parameter.