### PR TITLE
Updated documentation on getting user photo by size

### DIFF
--- a/api-reference/beta/api/profilephoto_get.md
+++ b/api-reference/beta/api/profilephoto_get.md
@@ -48,13 +48,13 @@ GET /users/<id | userPrincipalName>/contactfolders/<contactFolderId>/contacts/<i
 ### HTTP request to get the metadata for a specific photo size
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /me/photo/<size>
-GET /users/<id | userPrincipalName>/photo/<size>
-GET /groups/<id>/photo/<size>
-GET /me/contacts/<id>/photo/<size>
-GET /users/<id | userPrincipalName>/contacts/<id>/photo/<size>
-GET /me/contactfolders/<contactFolderId>/contacts/<id>/photo/<size>
-GET /users/<id | userPrincipalName>/contactfolders/<contactFolderId>/contacts/<id>/photo/<size>
+GET /me/photos/<size>
+GET /users/<id | userPrincipalName>/photos/<size>
+GET /groups/<id>/photos/<size>
+GET /me/contacts/<id>/photos/<size>
+GET /users/<id | userPrincipalName>/contacts/<id>/photos/<size>
+GET /me/contactfolders/<contactFolderId>/contacts/<id>/photos/<size>
+GET /users/<id | userPrincipalName>/contactfolders/<contactFolderId>/contacts/<id>/photos/<size>
 ```
 
 ### Parameters
@@ -95,6 +95,20 @@ Content-Type: image/jpg
 Contains the binary data of the requested photo. The HTTP response code is 200.
 
 ##### Request 2
+This request gets the 48x48 photo for the signed-in user.
+
+<!-- {
+  "blockType": "ignored"
+}-->
+```http
+GET https://graph.microsoft.com/beta/me/photos/48x48/$value
+Content-Type: image/jpg
+```
+
+##### Response 2
+Contains the binary data of the requested 48x48 photo. The HTTP response code is 200.
+
+##### Request 3
 This request gets the metadata of the user photo of the signed-in user.
 
 <!-- {
@@ -104,7 +118,7 @@ This request gets the metadata of the user photo of the signed-in user.
 GET https://graph.microsoft.com/beta/me/photo
 ```
 
-##### Response 2
+##### Response 3
 The following response data shows the photo metadata. Note: The response object shown here may be truncated for brevity.
 
 <!-- {

--- a/api-reference/v1.0/api/profilephoto_get.md
+++ b/api-reference/v1.0/api/profilephoto_get.md
@@ -4,15 +4,6 @@ Get the specified [profilePhoto](../resources/profilephoto.md) or its metadata (
 
 A GET operation looks for the specified photo in the user's mailbox on Exchange Online.
 
-The supported sizes of HD photos on Exchange Online are as follows: '48x48', '64x64', '96x96', 
-'120x120', '240x240', '360x360','432x432', '504x504', and '648x648'. 
-
-You can get the metadata of the largest available photo, or specify a size to get the metadata 
-for that photo size. If the size you request is not available, you can still get a smaller size that 
-the user has uploaded and made available. For example, if the user uploads a photo that is 504x504 pixels, 
-then all but the 648x648 size of photo will be available for download. If the specified size is not available 
-in the user's mailbox, the size of '1x1' is returned with the rest of metadata.
-
 ### Prerequisites
 One of the following **scopes** is required to execute this API for:
 
@@ -43,24 +34,6 @@ GET /users/<id | userPrincipalName>/contacts/<id>/photo
 GET /me/contactfolders/<contactFolderId>/contacts/<id>/photo
 GET /users/<id | userPrincipalName>/contactfolders/<contactFolderId>/contacts/<id>/photo
 ```
-
-### HTTP request to get the metadata for a specific photo size
-<!-- { "blockType": "ignored" } -->
-```http
-GET /me/photo/<size>
-GET /users/<id | userPrincipalName>/photo/<size>
-GET /groups/<id>/photo/<size>
-GET /me/contacts/<id>/photo/<size>
-GET /users/<id | userPrincipalName>/contacts/<id>/photo/<size>
-GET /me/contactfolders/<contactFolderId>/contacts/<id>/photo/<size>
-GET /users/<id | userPrincipalName>/contactfolders/<contactFolderId>/contacts/<id>/photo/<size>
-```
-
-### Parameters
-| Parameter       | Type | Description|
-|:-----------|:------|:----------|
-|_URL parameters_| | |
-| size  | string  | A photo size. |
 
 ### Optional query parameters
 This method supports the [OData Query Parameters](http://graph.microsoft.io/docs/overview/query_parameters) to help customize the response.


### PR DESCRIPTION
- Getting a photo by size is only available on /beta
- GET /me/photo/[size] should be /me/photos/[size]
- Added an example on the beta endpoint for getting the authenticated users 48x48 photo