### PR TITLE
Added 'type' property

### DIFF
--- a/api-reference/beta/resources/physicaladdress.md
+++ b/api-reference/beta/resources/physicaladdress.md
@@ -11,6 +11,7 @@ Represents the street address of a resource such as a contact or event.
 |postalCode|String|The postal code.|
 |state|String|The state.|
 |street|String|The street.|
+|type|String|The type of address. Possible values are: home, business, other.|
 
 ## JSON representation
 
@@ -30,7 +31,8 @@ Here is a JSON representation of the resource
   "countryOrRegion": "string",
   "postalCode": "string",
   "state": "string",
-  "street": "string"
+  "street": "string",
+  "type": "string"
 }
 
 ```


### PR DESCRIPTION
I was not able to save a physical address to a contact without providing the 'type' property. If more possible values are known, they should be added.